### PR TITLE
feat: change logging_simulator.launch arg value

### DIFF
--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -19,6 +19,7 @@
   <arg name="rviz" default="true" description="launch rviz" />
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
+  <arg name="scenario_simulation" default="true" description="use scenario simulation"/>
   <arg name="vehicle_simulation" default="false" description="use vehicle simulation"/>
 
   <!-- Global parameters -->
@@ -108,7 +109,7 @@
 
   <!-- Simulator -->
   <include file="$(find-pkg-share simulator_launch)/launch/simulator.launch.xml">
-    <arg name="scenario_simulation" value="true"/>
+    <arg name="scenario_simulation" value="$(var scenario_simulation)"/>
     <arg name="vehicle_simulation" value="false"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
   </include>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -108,7 +108,7 @@
 
   <!-- Simulator -->
   <include file="$(find-pkg-share simulator_launch)/launch/simulator.launch.xml">
-    <arg name="scenario_simulation" value="false"/>
+    <arg name="scenario_simulation" value="true"/>
     <arg name="vehicle_simulation" value="false"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
   </include>


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

[#462](https://github.com/tier4/autoware_launcher/pull/462)

## Description

- This PR fixes a link above that caused dummy_perception_publisher to output an empty point cloud.

## Review Procedure

- arg name="scenario_simulation" value="true"  in Simulator Section

## Remarks

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
