### PR TITLE
fix: perception launcher syntax error

### DIFF
--- a/perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -265,7 +265,7 @@ class GroundSegmentationPipeline:
             components.append(
                 self.get_additional_lidars_concatenated_component(
                     input_topics=[common_pipeline_output]
-                    + list(map(lambda x: f"{x}/pointcloud"), additional_lidars),
+                    + list(map(lambda x: f"{x}/pointcloud", additional_lidars)),
                     output_topic=relay_topic if use_ransac else output_topic,
                 )
             )


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

fix following error:

```sh
Task exception was never retrieved                                                                                                                                                                             
future: <Task finished name='Task-2' coro=<LaunchService._process_one_event() done, defined at /opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py:226> exception=TypeError('map() must have
 at least two arguments.')>                                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                             
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 228, in _process_one_event                                                                                               
    await self.__process_event(next_event)                                                                                                                                                                     
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 248, in __process_event                                                                                                  
    visit_all_entities_and_collect_futures(entity, self.__context))                                                                                                                                            
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures                                     
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)                                                                                                                           
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures                                     
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)                                                                                                                           
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures                                     
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)                                                                                                                           
  [Previous line repeated 8 more times]                                                                                                                                                                        
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures                                     
    sub_entities = entity.visit(context)                                                                                                                                                                       
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/action.py", line 108, in visit                                                                                                                    
    return self.execute(context)                                                                                                                                                                               
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/actions/opaque_function.py", line 75, in execute                                                                                                  
    return self.__function(context, *self.__args, **self.__kwargs)                                                                                                                                             
  File "/home/satoshi/autoware.proj.gsm8/install/perception_launch/share/perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py", line 462, in launch_setup          
    pipeline.create_single_frame_obstacle_segmentation_components(                                                                                                                                             
  File "/home/satoshi/autoware.proj.gsm8/install/perception_launch/share/perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py", line 268, in create_single_frame_ob
stacle_segmentation_components                                                                                                                                                                                 
    + list(map(lambda x: f"{x}/pointcloud"), additional_lidars),                                                                                                                                               
TypeError: map() must have at least two arguments.
```

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
