### PR TITLE
add rosbridge launch

### DIFF
--- a/autoware_api_launch/launch/autoware_api.launch.xml
+++ b/autoware_api_launch/launch/autoware_api.launch.xml
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="respawn" default="true" />
+
   <!-- awapi (deprecated) -->
   <group>
     <include file="$(find-pkg-share awapi_awiv_adapter)/launch/awapi_awiv_adapter.launch.xml"/>
@@ -18,5 +20,11 @@
     <push-ros-namespace namespace="autoware_api/utils"/>
     <include file="$(find-pkg-share path_distance_calculator)/launch/path_distance_calculator.launch.xml"/>
   </group>
+
+  <!-- rosbridge -->
+  <!-- TODO:　respawn will work once rosbridge is fixed. I'll delete this comment when it's done. -->
+  <include file="$(find-pkg-share rosbridge_server)/launch/rosbridge_websocket_launch.xml">
+      <arg name="respawn" value="$(var respawn)"/>
+  </include>
 
 </launch>

--- a/autoware_api_launch/launch/autoware_api.launch.xml
+++ b/autoware_api_launch/launch/autoware_api.launch.xml
@@ -22,7 +22,7 @@
   </group>
 
   <!-- rosbridge -->
-  <!-- TODO:　respawn will work once rosbridge is fixed. I'll delete this comment when it's done. -->
+  <!-- TODO:　respawn will work once https://github.com/ros2/launch/pull/569 is released. I'll delete this comment when it's done. -->
   <include file="$(find-pkg-share rosbridge_server)/launch/rosbridge_websocket_launch.xml">
       <arg name="respawn" value="$(var respawn)"/>
   </include>

--- a/autoware_api_launch/launch/autoware_api.launch.xml
+++ b/autoware_api_launch/launch/autoware_api.launch.xml
@@ -22,7 +22,7 @@
   </group>
 
   <!-- rosbridge -->
-  <!-- TODO:　respawn will work once https://github.com/ros2/launch/pull/569 is released. I'll delete this comment when it's done. -->
+  <!-- TODO: respawn will work once https://github.com/ros2/launch/pull/569 is released. I'll delete this comment when it's done. -->
   <include file="$(find-pkg-share rosbridge_server)/launch/rosbridge_websocket_launch.xml">
       <arg name="respawn" value="$(var respawn)"/>
   </include>


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

https://github.com/autowarefoundation/autoware.universe/pull/318

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Start rosbridge with api launch file.
And remove rosbridge launch from web_controller
<!-- Describe what this PR changes. -->

## Review Procedure

- `ros2 launch autoware_api_launch autoware_api.launch.xml init_simulator_pose:=false init_localization_pose:=false`
- check `ros2 node list|grep rosbridge`

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
