### PR TITLE
chore: fix CI settings

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -10,7 +10,7 @@
     - source: .markdownlint.yaml
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
-    - source: .prettierrc
+    - source: .prettierrc.yaml
     - source: .yamllint.yaml
     - source: CPPLINT.cfg
     - source: setup.cfg


### PR DESCRIPTION
Added missing `.yaml` in `sync-files.yaml`.