### PR TITLE
chore: update settings of sync-files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,6 +1,7 @@
 - repository: autowarefoundation/autoware
   files:
     - source: .github/dependabot.yaml
+    - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-differential.yaml
@@ -18,29 +19,3 @@
   files:
     - source: .github/workflows/build-and-test.yaml
     - source: .github/workflows/build-and-test-differential.yaml
-    - source: .github/workflows/pre-commit.yaml
-
-- repository: autowarefoundation/autoware.universe
-  files:
-    - source: system/ad_service_state_monitor/config/ad_service_state_monitor.param.yaml
-      dest: system_launch/config/ad_service_state_monitor.param.yaml
-    - source: system/ad_service_state_monitor/config/ad_service_state_monitor.planning_simulation.param.yaml
-      dest: system_launch/config/ad_service_state_monitor.planning_simulation.param.yaml
-    - source: system/system_error_monitor/config/system_error_monitor.param.yaml
-      dest: system_launch/config/system_error_monitor.param.yaml
-    - source: system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
-      dest: system_launch/config/system_error_monitor.planning_simulation.param.yaml
-    - source: system/system_monitor/config/cpu_monitor.param.yaml
-      dest: system_launch/config/system_monitor/cpu_monitor.param.yaml
-    - source: system/system_monitor/config/gpu_monitor.param.yaml
-      dest: system_launch/config/system_monitor/gpu_monitor.param.yaml
-    - source: system/system_monitor/config/hdd_monitor.param.yaml
-      dest: system_launch/config/system_monitor/hdd_monitor.param.yaml
-    - source: system/system_monitor/config/mem_monitor.param.yaml
-      dest: system_launch/config/system_monitor/mem_monitor.param.yaml
-    - source: system/system_monitor/config/net_monitor.param.yaml
-      dest: system_launch/config/system_monitor/net_monitor.param.yaml
-    - source: system/system_monitor/config/ntp_monitor.param.yaml
-      dest: system_launch/config/system_monitor/ntp_monitor.param.yaml
-    - source: system/system_monitor/config/process_monitor.param.yaml
-      dest: system_launch/config/system_monitor/process_monitor.param.yaml

--- a/.github/sync-param-files.yaml
+++ b/.github/sync-param-files.yaml
@@ -1,0 +1,30 @@
+- repository: tier4/autoware.universe
+  files:
+    # system
+    ## ad_service_state_monitor
+    - source: system/ad_service_state_monitor/config/ad_service_state_monitor.param.yaml
+      dest: system_launch/config/ad_service_state_monitor.param.yaml
+    - source: system/ad_service_state_monitor/config/ad_service_state_monitor.planning_simulation.param.yaml
+      dest: system_launch/config/ad_service_state_monitor.planning_simulation.param.yaml
+
+    ## system_error_monitor
+    - source: system/system_error_monitor/config/system_error_monitor.param.yaml
+      dest: system_launch/config/system_error_monitor.param.yaml
+    - source: system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+      dest: system_launch/config/system_error_monitor.planning_simulation.param.yaml
+
+    ## system_monitor
+    - source: system/system_monitor/config/cpu_monitor.param.yaml
+      dest: system_launch/config/system_monitor/cpu_monitor.param.yaml
+    - source: system/system_monitor/config/gpu_monitor.param.yaml
+      dest: system_launch/config/system_monitor/gpu_monitor.param.yaml
+    - source: system/system_monitor/config/hdd_monitor.param.yaml
+      dest: system_launch/config/system_monitor/hdd_monitor.param.yaml
+    - source: system/system_monitor/config/mem_monitor.param.yaml
+      dest: system_launch/config/system_monitor/mem_monitor.param.yaml
+    - source: system/system_monitor/config/net_monitor.param.yaml
+      dest: system_launch/config/system_monitor/net_monitor.param.yaml
+    - source: system/system_monitor/config/ntp_monitor.param.yaml
+      dest: system_launch/config/system_monitor/ntp_monitor.param.yaml
+    - source: system/system_monitor/config/process_monitor.param.yaml
+      dest: system_launch/config/system_monitor/process_monitor.param.yaml

--- a/.github/workflows/sync-param-files.yaml
+++ b/.github/workflows/sync-param-files.yaml
@@ -1,0 +1,23 @@
+name: sync-param-files
+
+on:
+  schedule:
+    - cron: 0 19 * * * # run at 4 AM JST
+  workflow_dispatch:
+
+jobs:
+  sync-param-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-files
+        uses: autowarefoundation/autoware-github-actions/sync-files@tier4/proposal
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          config: .github/sync-param-files.yaml


### PR DESCRIPTION
- Change the source of pre-commit.yaml
- Split sync-param-files workflow and add comments
- Fetch param files from tier4/autoware.universe, not from autowarefoundation.