### PR TITLE
fix(behavior_path_planner): revert road shoulder margin to zero

### DIFF
--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -24,7 +24,7 @@
       min_nominal_avoidance_speed: 7.0  # [m/s]
       min_sharp_avoidance_speed: 1.0    # [m/s]
 
-      road_shoulder_safety_margin: 0.5 # [m]
+      road_shoulder_safety_margin: 0.0 # [m]
 
       max_right_shift_length: 5.0
       max_left_shift_length: 5.0


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## PR Type

Fix

## Related Links

## Description

To reduce the number of parameters to be tune, it is decided to revert the `road_shoulder_safety_margin` to zero. The reason is that the parameter is dependent on the lanelet/ODD, therefore it might be different depending on the area.

## Review Procedure

Use psim to simulated parked road avoidance scenario.

## Remarks

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Code follows [coding guidelines][coding-guidelines]
- [X] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
