### PR TITLE
feat(control_launch): add disable-emergency option in velocity_controller

### DIFF
--- a/control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
+++ b/control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
@@ -5,6 +5,7 @@
 
     enable_smooth_stop: true
     enable_overshoot_emergency: true
+    enable_large_tracking_error_emergency: true
     enable_slope_compensation: true
 
     # state transition


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- New Feature


## Related Links

See below.

## Description

Add parameter for https://github.com/autowarefoundation/autoware.universe/pull/1201

The default parameter enables emergency stop.


## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets
- [x] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
