### PR TITLE
fix(perception_launch): remove duplicated namespace of clustering in camera-lidar-fusion mode

### DIFF
--- a/perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -130,9 +130,9 @@
 
       <group>
         <include file="$(find-pkg-share object_range_splitter)/launch/object_range_splitter.launch.xml">
-          <arg name="input/object" value="camera_lidar_fusion/objects"/>
-          <arg name="output/long_range_object" value="camera_lidar_fusion/long_range_objects"/>
-          <arg name="output/short_range_object" value="camera_lidar_fusion/short_range_objects"/>
+          <arg name="input/object" value="objects"/>
+          <arg name="output/long_range_object" value="long_range_objects"/>
+          <arg name="output/short_range_object" value="short_range_objects"/>
           <arg name="split_range" value="30.0"/>
         </include>
       </group>


### PR DESCRIPTION
Signed-off-by: yukke42 <yusuke.muramatsu@tier4.jp>

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

- https://github.com/autowarefoundation/autoware.universe/pull/1655
<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Remove the duplicated name space of camera_lidar_fusion in object_range_splitter.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
