### PR TITLE
feat(trajectory_follower): keep stop until the steering control is done

### DIFF
--- a/control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
+++ b/control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
@@ -6,7 +6,7 @@
     enable_overshoot_emergency: true
     enable_large_tracking_error_emergency: true
     enable_slope_compensation: true
-    enable_keep_stopped_until_steer_convergence: false
+    enable_keep_stopped_until_steer_convergence: true
 
     # state transition
     drive_state_stop_dist: 0.5

--- a/control_launch/config/trajectory_follower/mpc_follower.param.yaml
+++ b/control_launch/config/trajectory_follower/mpc_follower.param.yaml
@@ -56,7 +56,7 @@
     stop_state_entry_ego_speed: 0.001
     stop_state_entry_target_speed: 0.001
     converged_steer_rad: 0.1
-    keep_steer_control_until_converged: false
+    keep_steer_control_until_converged: true
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
 


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

enable keeping steer control until converged by default for checking pull_over geometric parking in scenario tests.

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

https://github.com/autowarefoundation/autoware.universe/pull/1672

## Description

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
