### PR TITLE
feat(obstacle_avoidance_planne): enable plan_from_ego by default

### DIFF
--- a/planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -58,7 +58,7 @@
       option:
         steer_limit_constraint: true
         fix_points_around_ego: true
-        plan_from_ego: false
+        plan_from_ego: true
         max_plan_from_ego_length: 10.0
         visualize_sampling_num: 1
         enable_manual_warm_start: true


### PR DESCRIPTION

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

https://github.com/autowarefoundation/autoware.universe/pull/1673

## Description

<!-- Describe what this PR changes. -->

enable keeping steer control until converged by default for checking pull_over geometric parking in scenario tests.

If the path length is within 10m after stopping (5m before the basic ego is guaranteed, so 5m from ego to the goal), the path is planned from ego.
If plan_from_ego is set to true, there was a problem that the optimization could not be solved if the path was long when the vehicle stopped, but this time, it is limited to short paths (it is assumed that there are almost no cases that satisfy the condition except for pull_over, pull_out, free_space_planner). So far, we have not encountered any cases where the optimization is not solvable under these conditions.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
