### PR TITLE
feat(shift_decider): add shift decider config

### DIFF
--- a/control_launch/config/shift_decider/shift_decider.param.yaml
+++ b/control_launch/config/shift_decider/shift_decider.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    park_on_goal: true

--- a/control_launch/launch/control.launch.py
+++ b/control_launch/launch/control.launch.py
@@ -56,6 +56,10 @@ def launch_setup(context, *args, **kwargs):
     with open(operation_mode_transition_manager_param_path, "r") as f:
         operation_mode_transition_manager_param = yaml.safe_load(f)["/**"]["ros__parameters"]
 
+    shift_decider_param_path = LaunchConfiguration("shift_decider_param_path").perform(context)
+    with open(shift_decider_param_path, "r") as f:
+        shift_decider_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
     controller_component = ComposableNode(
         package="trajectory_follower_nodes",
         plugin="autoware::motion::control::trajectory_follower_nodes::Controller",
@@ -114,9 +118,7 @@ def launch_setup(context, *args, **kwargs):
             ("output/gear_cmd", "/control/shift_decider/gear_cmd"),
         ],
         parameters=[
-            {
-                "park_on_goal": True,
-            }
+            shift_decider_param,
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
@@ -303,6 +305,14 @@ def generate_launch_description():
             "/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml",
         ],
         "path to the parameter file of vehicle_cmd_gate",
+    )
+    add_launch_arg(
+        "shift_decider_param_path",
+        [
+            FindPackageShare("control_launch"),
+            "/config/shift_decider/shift_decider_param.param.yaml",
+        ],
+        "path to the parameter file of shift_decider",
     )
 
     # vehicle cmd gate

--- a/control_launch/launch/control.launch.xml
+++ b/control_launch/launch/control.launch.xml
@@ -6,6 +6,7 @@
   <arg name="latlon_muxer_param_path" default="$(find-pkg-share control_launch)/config/trajectory_follower/latlon_muxer.param.yaml"/>
   <arg name="vehicle_cmd_gate_param_path" default="$(find-pkg-share control_launch)/config/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml"/>
   <arg name="operation_mode_transition_manager_param_path" default="$(find-pkg-share control_launch)/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml"/>
+  <arg name="shift_decider_param_path" default="$(find-pkg-share control_launch)/config/shift_decider/shift_decider.param.yaml"/>
 
   <include file="$(find-pkg-share control_launch)/launch/control.launch.py">
     <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)" />
@@ -14,6 +15,7 @@
     <arg name="latlon_muxer_param_path" value="$(var latlon_muxer_param_path)"/>
     <arg name="vehicle_cmd_gate_param_path" value="$(var vehicle_cmd_gate_param_path)"/>
     <arg name="operation_mode_transition_manager_param_path" value="$(var operation_mode_transition_manager_param_path)"/>
+    <arg name="shift_decider_param_path" value="$(var shift_decider_param_path)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
## Description

Add shift_decider config to follow https://github.com/autowarefoundation/autoware.universe/pull/1857

I checked the ros parameter was changed depending on the true/false in the new yaml file.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code follows [coding guidelines][coding-guidelines]
- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [x] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
