### PR TITLE
chore: change control launch

### DIFF
--- a/control_launch/launch/control.launch.py
+++ b/control_launch/launch/control.launch.py
@@ -319,7 +319,7 @@ def generate_launch_description():
         "shift_decider_param_path",
         [
             FindPackageShare("control_launch"),
-            "/config/shift_decider/shift_decider_param.param.yaml",
+            "/config/shift_decider/shift_decider.param.yaml",
         ],
         "path to the parameter file of shift_decider",
     )

--- a/control_launch/launch/control.launch.xml
+++ b/control_launch/launch/control.launch.xml
@@ -3,7 +3,6 @@
   <arg name="lateral_controller_mode" description="options for lateral_controller_mode: mpc_follower, pure_pursuit"/>
   <arg name="lat_controller_param_path" default="$(find-pkg-share control_launch)/config/trajectory_follower/$(var lateral_controller_mode).param.yaml"/>
   <arg name="lon_controller_param_path" default="$(find-pkg-share control_launch)/config/trajectory_follower/longitudinal_controller.param.yaml" description="path to the longitudinal controller param file"/>
-  <arg name="latlon_muxer_param_path" default="$(find-pkg-share control_launch)/config/trajectory_follower/latlon_muxer.param.yaml"/>
   <arg name="vehicle_cmd_gate_param_path" default="$(find-pkg-share control_launch)/config/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml"/>
   <arg name="operation_mode_transition_manager_param_path" default="$(find-pkg-share control_launch)/config/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml"/>
   <arg name="shift_decider_param_path" default="$(find-pkg-share control_launch)/config/shift_decider/shift_decider.param.yaml"/>
@@ -12,7 +11,6 @@
     <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)" />
     <arg name="lat_controller_param_path" value="$(var lat_controller_param_path)"/>
     <arg name="lon_controller_param_path" value="$(var lon_controller_param_path)"/>
-    <arg name="latlon_muxer_param_path" value="$(var latlon_muxer_param_path)"/>
     <arg name="vehicle_cmd_gate_param_path" value="$(var vehicle_cmd_gate_param_path)"/>
     <arg name="operation_mode_transition_manager_param_path" value="$(var operation_mode_transition_manager_param_path)"/>
     <arg name="shift_decider_param_path" value="$(var shift_decider_param_path)"/>


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Chore

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description
- remove unused parameter in control.launch.xml
- Fix wrong parameter-file name in control.launch.py


<!-- Describe what this PR changes. -->

## Review Procedure
Confirmithat the autoware starts normally with following command
$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_id:=default vehicle_model:=lexus sensor_model:=aip_xx1 map_path:=[MAP PATH]


<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
