### PR TITLE
fix(planning_launch): move lane change minimum prepare dist to bpp.param

### DIFF
--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -6,6 +6,7 @@
     backward_length_buffer_for_end_of_pull_over: 5.0
     backward_length_buffer_for_end_of_pull_out: 5.0
     minimum_lane_change_length: 12.0
+    minimum_lane_change_prepare_distance: 2.0 # [m]
     minimum_pull_over_length: 16.0
 
     drivable_area_resolution: 0.1

--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -3,7 +3,6 @@
     lane_change:
       lane_change_prepare_duration: 4.0         # [s]
       lane_changing_duration: 8.0               # [s]
-      minimum_lane_change_prepare_distance: 2.0 # [m]
       lane_change_finish_judge_buffer: 3.0      # [m]
       minimum_lane_change_velocity: 5.6         # [m/s]
       prediction_time_resolution: 0.5           # [s]


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## PR Type

- Bug Fix

## Related Links

https://github.com/autowarefoundation/autoware.universe/pull/2413


## Description

Currently, for lane change, when computing end of lane stopping pose only  `backward_length_buffer_for_end_of_lane + minimum_lane_change_length` are considered. If ego velocity is `0m/s`, prepare distance is also `0 m`. 

The updated lane change module introduces `minimum_lane_change_dist`. Now, when increasing `minimum_lane_change_prepare_dist` parameter, the minimum lane change distance should increase accordingly. But currently, the computation doesn't include the minimum prepare distance.

Therefore, this PR aims to solve this by including `minimum_lane_change_prepare_dist` into `minimum_lane_change_distance` calculation.

![Screenshot from 2022-12-01 00-18-22](https://user-images.githubusercontent.com/93502286/204838618-16e62375-52c0-4ee8-a39a-b6c33947a092.png)

## Review Procedure

Test lane change is working using PSIM as follows.

https://user-images.githubusercontent.com/93502286/204836678-e087a92d-5700-4318-bdea-5f77ad9fd2cb.mp4

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
