### PR TITLE
fix(planning_launch): lane change collision check default

### DIFF
--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -23,11 +23,11 @@
 
     lateral_distance_max_threshold: 2.0
     longitudinal_distance_min_threshold: 3.0
-    expected_front_deceleration: -0.5
+    expected_front_deceleration: -1.0
     expected_rear_deceleration: -1.0
 
-    expected_front_deceleration_for_abort: -2.0
-    expected_rear_deceleration_for_abort: -2.5
+    expected_front_deceleration_for_abort: -1.0
+    expected_rear_deceleration_for_abort: -2.0
 
     rear_vehicle_reaction_time: 2.0
     rear_vehicle_safety_time_margin: 2.0

--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -5,7 +5,7 @@
       lane_changing_duration: 8.0               # [s]
       minimum_lane_change_prepare_distance: 2.0 # [m]
       lane_change_finish_judge_buffer: 3.0      # [m]
-      minimum_lane_change_velocity: 5.6         # [m/s]
+      minimum_lane_change_velocity: 2.78        # [m/s]
       prediction_time_resolution: 0.5           # [s]
       maximum_deceleration: 1.0                 # [m/s2]
       lane_change_sampling_num: 10
@@ -13,7 +13,7 @@
       abort_lane_change_angle_thresh: 10.0      # [deg]
       abort_lane_change_distance_thresh: 0.3    # [m]
       enable_abort_lane_change: true
-      enable_collision_check_at_prepare_phase: true
+      enable_collision_check_at_prepare_phase: false
       use_predicted_path_outside_lanelet: true
       use_all_predicted_path: false
       publish_debug_marker: false

--- a/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -13,7 +13,7 @@
       abort_lane_change_angle_thresh: 10.0      # [deg]
       abort_lane_change_distance_thresh: 0.3    # [m]
       enable_abort_lane_change: true
-      enable_collision_check_at_prepare_phase: false
+      enable_collision_check_at_prepare_phase: true
       use_predicted_path_outside_lanelet: true
       use_all_predicted_path: false
       publish_debug_marker: false


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

[fix(behavior_path_planner): lane change check default parameters #2575
](https://github.com/autowarefoundation/autoware.universe/pull/2575)

## Description

To enhance current CI lane change scenario, the parameters are modified.

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
