### PR TITLE
fix(lane change): adaptive safety check time parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -31,4 +31,4 @@
     expected_rear_deceleration_for_abort: -2.0
 
     rear_vehicle_reaction_time: 2.0
-    rear_vehicle_safety_time_margin: 2.0
+    rear_vehicle_safety_time_margin: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -2,7 +2,6 @@
   ros__parameters:
     lane_change:
       lane_change_prepare_duration: 4.0         # [s]
-      lane_changing_safety_check_duration: 8.0  # [s]
 
       minimum_lane_change_prepare_distance: 2.0 # [m]
       minimum_lane_change_length: 16.5          # [m]
@@ -18,9 +17,9 @@
       lane_change_sampling_num: 10
 
       # collision check
-      enable_collision_check_at_prepare_phase: true
+      enable_collision_check_at_prepare_phase: false
       prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
-      use_predicted_path_outside_lanelet: true
+      use_predicted_path_outside_lanelet: false
       use_all_predicted_path: false
 
       # abort


### PR DESCRIPTION
## PR Type

Because safety check is now adaptive, we dont need lane change safety check time anymore.
Also the parameter reflected current stable lane change parameter that was used in odaiba test.

## Related Links

https://github.com/autowarefoundation/autoware.universe/pull/2704

## Description

Changes lane change parameters

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Code follows [coding guidelines][coding-guidelines]
- [X] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
