### PR TITLE
feat(intersection): add param for overshoot from stop line

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -20,6 +20,7 @@
       use_stuck_stopline: false # stopline generate before the intersection lanelet when is_stuck
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled
+      stop_overshoot_margin: 0.5 # [m] overshoot margin for stuck, collsion detection
 
     merge_from_private_road:
       stop_duration_sec: 1.0


### PR DESCRIPTION
Signed-off-by: Mamoru Sobue <mamoru.sobue@tier4.jp>

## PR Type

- Improvement

## Related Links

feature PR: https://github.com/autowarefoundation/autoware.universe/pull/2756
awf paraam PR: https://github.com/autowarefoundation/autoware_launch/pull/188

## Description

Add param for the overshoot from stuck stop line that was previously hardcoded

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Code follows [coding guidelines][coding-guidelines]
- [X] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [X] Commits are properly organized and messages are according to the guideline
- [X] Code follows [coding guidelines][coding-guidelines]
- [X] (Optional) Unit tests have been written for new behavior
- [X] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
