### PR TITLE
fix(occlusion_spot): occlusion spot parameter disable as default

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -7,7 +7,7 @@
     launch_blind_spot: true
     launch_detection_area: true
     launch_virtual_traffic_light: true
-    launch_occlusion_spot: true
+    launch_occlusion_spot: false
     launch_no_stopping_area: true
     launch_run_out: false
     launch_speed_bump: false


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QW0GU6P7/p1675231129649159)>

## Description

While testing the scenario in Evaluator, it is found that some scenarios has failed, due to occlusion spot causes ego vehicle to slow down. 

This PR aim to turn off occlusion spot by default.

## Review Procedure

Test occlusion spot related scenario and see that it is not activated.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Code follows [coding guidelines][coding-guidelines]
- [X] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code follows [coding guidelines][coding-guidelines]
- [ ] (Optional) Unit tests have been written for new behavior
- [x] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[coding-guidelines]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/1194394777/T4
[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
